### PR TITLE
Deployment detail improvements

### DIFF
--- a/src/app/modules/deployments/components/deployment-detail/deployment-detail.component.html
+++ b/src/app/modules/deployments/components/deployment-detail/deployment-detail.component.html
@@ -24,6 +24,7 @@
             <h2>{{ deployment?.title }}</h2>
             <p>
                 <img
+                    *ngIf="deployment"
                     src="https://img.shields.io/badge/status-{{ statusBadge }}"
                     width="125"
                 />
@@ -133,6 +134,9 @@
                                         mat-button
                                         [href]="endpoint.value"
                                         target="_blank"
+                                        [disabled]="
+                                            !isActiveEndPoint(endpoint.key)
+                                        "
                                     >
                                         {{ $any(endpoint.key) | uppercase }}
                                         <mat-icon>open_in_new</mat-icon></a

--- a/src/app/modules/deployments/components/deployment-detail/deployment-detail.component.ts
+++ b/src/app/modules/deployments/components/deployment-detail/deployment-detail.component.ts
@@ -22,6 +22,13 @@ export class DeploymentDetailComponent implements OnInit {
     isLoading = false;
     protected deploymentHasError = false;
 
+    isActiveEndPoint(endpoint: string) {
+        return (
+            this.deployment?.active_endpoints &&
+            this.deployment.active_endpoints.indexOf(endpoint) > -1
+        );
+    }
+
     ngOnInit(): void {
         if (this.data.uuid) {
             this.isLoading = true;

--- a/src/app/modules/deployments/components/deployments-list/deployments-list.component.html
+++ b/src/app/modules/deployments/components/deployments-list/deployments-list.component.html
@@ -50,7 +50,7 @@
                                 <a
                                     mat-button
                                     [disabled]="!isDeploymentRunning(row)"
-                                    [href]="row.mainEndpoint"
+                                    [href]="getMainEndpoint(row)"
                                     target="_blank"
                                     class="action-button-in-cell"
                                     (click)="$event.stopPropagation()"

--- a/src/app/modules/deployments/components/deployments-list/deployments-list.component.ts
+++ b/src/app/modules/deployments/components/deployments-list/deployments-list.component.ts
@@ -28,7 +28,7 @@ interface deploymentTableRow {
     containerName: string;
     gpus: string | number;
     creationTime: string;
-    endpoints?: object | undefined;
+    endpoints?: { [index: string]: string } | undefined;
     mainEndpoint: string;
     error_msg?: string;
 }
@@ -192,6 +192,15 @@ export class DeploymentsListComponent implements OnInit, OnDestroy {
         return row.endpoints;
     }
 
+    getMainEndpoint(row: deploymentTableRow) {
+        const mainEndpoint = row.mainEndpoint;
+        if (row.endpoints && row.endpoints[mainEndpoint]) {
+            return row.endpoints[mainEndpoint];
+        } else {
+            return '';
+        }
+    }
+
     hasDeploymentErrors(row: deploymentTableRow) {
         return row.error_msg;
     }
@@ -201,17 +210,13 @@ export class DeploymentsListComponent implements OnInit, OnDestroy {
     }
 
     openDeploymentDetailDialog(row: deploymentTableRow): void {
-        const dialogRef = this.dialog.open(DeploymentDetailComponent, {
+        this.dialog.open(DeploymentDetailComponent, {
             data: { uuid: row.uuid, isTool: false },
             width: '650px',
             maxWidth: '650px',
             minWidth: '650px',
             autoFocus: false,
             restoreFocus: false,
-        });
-
-        dialogRef.afterClosed().subscribe((result) => {
-            console.log('The dialog was closed', result);
         });
     }
 

--- a/src/app/modules/deployments/components/deployments-list/tools-table/tools-table.component.html
+++ b/src/app/modules/deployments/components/deployments-list/tools-table/tools-table.component.html
@@ -54,7 +54,7 @@
                     </div>
 
                     <ng-template #fedServerQuickAccess>
-                        <div>
+                        <div matTooltip="Copy to clipboard">
                             <a
                                 mat-button
                                 [disabled]="!isToolRunning(row)"

--- a/src/app/modules/deployments/components/deployments-list/tools-table/tools-table.component.html
+++ b/src/app/modules/deployments/components/deployments-list/tools-table/tools-table.component.html
@@ -32,7 +32,13 @@
                         <mat-icon color="accent" id="infoIcon">info</mat-icon>
                     </button>
 
-                    <div matTooltip="Quick access">
+                    <div
+                        *ngIf="
+                            !isFederatedServer(row);
+                            else fedServerQuickAccess
+                        "
+                        matTooltip="Quick access"
+                    >
                         <a
                             mat-button
                             [disabled]="!isToolRunning(row)"
@@ -46,6 +52,21 @@
                             >
                         </a>
                     </div>
+
+                    <ng-template #fedServerQuickAccess>
+                        <div>
+                            <a
+                                mat-button
+                                [disabled]="!isToolRunning(row)"
+                                class="action-button-in-cell"
+                                [copy-to-clipboard]="row.mainEndpoint"
+                            >
+                                <mat-icon color="accent" id="accessIcon"
+                                    >content_copy</mat-icon
+                                >
+                            </a>
+                        </div>
+                    </ng-template>
 
                     <button
                         mat-button

--- a/src/app/modules/deployments/components/deployments-list/tools-table/tools-table.component.ts
+++ b/src/app/modules/deployments/components/deployments-list/tools-table/tools-table.component.ts
@@ -229,6 +229,10 @@ export class ToolsTableComponent implements OnInit, OnDestroy {
             });
     }
 
+    isFederatedServer(row: toolTableRow) {
+        return row.mainEndpoint.includes('fedserver');
+    }
+
     ngOnInit(): void {
         this.dataset = [];
         this.getToolsList();

--- a/src/app/modules/marketplace/components/module-train/general-conf-form/general-conf-form.component.html
+++ b/src/app/modules/marketplace/components/module-train/general-conf-form/general-conf-form.component.html
@@ -146,7 +146,7 @@
         >
             <mat-label>
                 {{
-                    'MODULES.MODULE-TRAIN.GENERAL-CONF-FORM.HOSTNAME'
+                    'MODULES.MODULE-TRAIN.GENERAL-CONF-FORM.CUSTOM-DOMAIN'
                         | translate
                 }}</mat-label
             >
@@ -162,7 +162,7 @@
                 "
             >
                 {{
-                    'MODULES.MODULE-TRAIN.GENERAL-CONF-FORM.DEPLOYMENT-TITLE-REQUIRED'
+                    'MODULES.MODULE-TRAIN.GENERAL-CONF-FORM.CUSTOM-DOMAIN-PATTERN-ERROR'
                         | translate
                 }}
             </mat-error>

--- a/src/app/modules/marketplace/components/module-train/general-conf-form/general-conf-form.component.html
+++ b/src/app/modules/marketplace/components/module-train/general-conf-form/general-conf-form.component.html
@@ -182,10 +182,8 @@
             <mat-icon
                 matSuffix
                 color="primary"
-                (click)="
-                    copyValueToClipboard(
-                        generalConfFormGroup.get('federatedSecretInput')?.value
-                    )
+                [copy-to-clipboard]="
+                    generalConfFormGroup.get('federatedSecretInput')?.value
                 "
                 class="copy-icon"
             >

--- a/src/app/modules/marketplace/components/module-train/general-conf-form/general-conf-form.component.ts
+++ b/src/app/modules/marketplace/components/module-train/general-conf-form/general-conf-form.component.ts
@@ -141,16 +141,6 @@ export class GeneralConfFormComponent implements OnInit {
 
     dockerTagOptions: { value: string; viewValue: string }[] = [];
 
-    copyValueToClipboard(value: string | null | undefined) {
-        if (value) {
-            this.clipboard.copy(value);
-            this._snackBar.open('Copied to clipboard!', 'X', {
-                duration: 3000,
-                panelClass: ['primary-snackbar'],
-            });
-        }
-    }
-
     ngOnInit(): void {
         this.parentForm = this.ctrlContainer.form;
         this.parentForm.addControl(

--- a/src/app/modules/marketplace/components/module-train/general-conf-form/general-conf-form.component.ts
+++ b/src/app/modules/marketplace/components/module-train/general-conf-form/general-conf-form.component.ts
@@ -135,7 +135,7 @@ export class GeneralConfFormComponent implements OnInit {
         ],
         dockerImageInput: [{ value: '', disabled: true }],
         dockerTagSelect: [''],
-        hostnameInput: [''],
+        hostnameInput: ['', [Validators.pattern('^[a-zA-Z0-9-]+$')]],
         federatedSecretInput: [{ value: '', disabled: true }],
     });
 

--- a/src/app/modules/marketplace/components/module-train/hardware-conf-form/hardware-conf-form.component.ts
+++ b/src/app/modules/marketplace/components/module-train/hardware-conf-form/hardware-conf-form.component.ts
@@ -76,7 +76,7 @@ export class HardwareConfFormComponent implements OnInit {
             ],
         ],
         descriptionInput: [''],
-        gpuModelSelect: [{ value: '', disabled: true }, [Validators.required]],
+        gpuModelSelect: [{ value: '', disabled: true }],
         ramMemoryInput: [
             '',
             [

--- a/src/app/shared/directives/copy-to-clipboard-directive.ts
+++ b/src/app/shared/directives/copy-to-clipboard-directive.ts
@@ -1,0 +1,27 @@
+import { Directive, HostListener, Input } from '@angular/core';
+import { MatSnackBar } from '@angular/material/snack-bar';
+import { Clipboard } from '@angular/cdk/clipboard';
+
+@Directive({
+    // eslint-disable-next-line @angular-eslint/directive-selector
+    selector: '[copy-to-clipboard]',
+})
+export class CopyToClipboardDirective {
+    @Input('copy-to-clipboard') value!: string | undefined | null;
+
+    constructor(
+        private clipboard: Clipboard,
+        private _snackBar: MatSnackBar
+    ) {}
+
+    @HostListener('click', ['$event'])
+    public onClick(event: MouseEvent): void {
+        event.preventDefault();
+        if (!this.value) return;
+        this.clipboard.copy(this.value);
+        this._snackBar.open('Copied to clipboard!', 'X', {
+            duration: 3000,
+            panelClass: ['primary-snackbar'],
+        });
+    }
+}

--- a/src/app/shared/interfaces/deployment.interface.ts
+++ b/src/app/shared/interfaces/deployment.interface.ts
@@ -12,7 +12,8 @@ export interface Deployment {
         memoryMB: number;
         diskMB: number;
     };
-    endpoints?: object;
+    endpoints?: { [index: string]: string };
+    active_endpoints?: [string];
     main_endpoint: string;
     alloc_ID?: string;
     error_msg?: string;

--- a/src/app/shared/shared.module.ts
+++ b/src/app/shared/shared.module.ts
@@ -8,9 +8,10 @@ import { MaterialModule } from './material.module';
 import { TranslateModule } from '@ngx-translate/core';
 import { ConfirmationDialogComponent } from './components/confirmation-dialog/confirmation-dialog.component';
 import { BreadcrumbModule } from 'xng-breadcrumb';
+import { CopyToClipboardDirective } from './directives/copy-to-clipboard-directive';
 
 @NgModule({
-    declarations: [ConfirmationDialogComponent],
+    declarations: [ConfirmationDialogComponent, CopyToClipboardDirective],
     imports: [CommonModule, MaterialModule],
     exports: [
         ReactiveFormsModule,
@@ -18,6 +19,7 @@ import { BreadcrumbModule } from 'xng-breadcrumb';
         RouterModule,
         TranslateModule,
         BreadcrumbModule,
+        CopyToClipboardDirective,
     ],
 })
 export class SharedModule {}

--- a/src/assets/i18n/en.json
+++ b/src/assets/i18n/en.json
@@ -33,8 +33,9 @@
             "RESOURCES": {
                 "CPU_NUM": "Number of CPUs",
                 "GPU_NUM": "Number of GPUs",
-                "DISKMB": "Disk memory",
-                "MEMORYMB": "RAM memory"
+                "DISK_MB": "Disk memory",
+                "MEMORY_MB": "RAM memory",
+                "CPU_MHZ": "CPU freq. in MHZ"
             }
         },
         "DEPLOYMENT-NAME": "Name",

--- a/src/assets/i18n/en.json
+++ b/src/assets/i18n/en.json
@@ -28,7 +28,7 @@
             "DESCRIPTION": "Description",
             "CREATION-TIME": "Creation time (UTC)",
             "DEPLOYMENT-ID": "Deployment ID",
-            "RESOURCES-ASSIGNED": "Resources assigned",
+            "RESOURCES-ASSIGNED": "Resources",
             "ENDPOINTS": "Endpoints",
             "RESOURCES": {
                 "CPU_NUM": "Number of CPUs",

--- a/src/assets/i18n/en.json
+++ b/src/assets/i18n/en.json
@@ -90,7 +90,8 @@
                 "DOCKER-IMAGE": "Docker image",
                 "DOCKER-TAG":  "Docker tag",
                 "FEDERATED-SECRET": "Federated secret",
-                "HOSTNAME": "Custom domain"
+                "CUSTOM-DOMAIN": "Custom domain",
+                "CUSTOM-DOMAIN-PATTERN-ERROR": "Only alphanumeric characters and hyphens (-) are allowed"
             },
             "HARDWARE-CONF-FORM": {
                 "TITLE": "Hardware options",


### PR DESCRIPTION
The following features/improvements are implemented:

- In the deployment's detail view not only the active endpoints will be clickable
- Show resources instead of resources assigned as now the API also returns the resources field if the job is queued
- Create copy to clipboard directive
- If a deployment is a federated server tool, show a copy to clipboard button instead of a quick access one
- Custom domain field can only contain alphanumeric characters and hyphens
- The GPU model is now an optional field.